### PR TITLE
Properly escape encoded space

### DIFF
--- a/output/volume-util.sh
+++ b/output/volume-util.sh
@@ -37,6 +37,6 @@ find_nix_volume() {
 
 configure_fstab() {
     volume="$1"
-    label=$(echo "$volume" | sed "s/ /\\040/g")
+    label=$(echo "$volume" | sed "s/ /\\\040/g")
     printf "\$a\nLABEL=%s /nix apfs rw,nobrowse\n.\nwq\n" "$label" | EDITOR=ed vifs
 }


### PR DESCRIPTION
Otherwise, the volume is not mounted on boot.

```
$ echo "Nix Store" | sed "s/ /\\040/g"
Nix040Store
$ echo "Nix Store" | sed "s/ /\\\040/g"                                                                                                                                                  
Nix\040Store
```